### PR TITLE
Fix Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CF CLI Recorder [![Build Status](https://travis-ci.org/simonleung8/cli-plugin-re
 This plugin records sets of CF CLI commands, and allows you to playback a set or sets commands anytime.
 
 
-##Usage
+## Usage
 ```
 $ cf record <name>
 
@@ -16,21 +16,21 @@ After recording, play back with `replay`, you can play back 1 or more recorded c
 $ cf replay <name>
 ```
 
-##Installation
-#####Install from CLI (v.6.10.0 and up)
+## Installation
+##### Install from CLI (v.6.10.0 and up)
   ```
   $ cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org/
   $ cf install-plugin CLI-Recorder -r CF-Community
   ```
   
   
-#####Install with binary
+##### Install with binary
 - Download the binary [`win64`](https://github.com/simonleung8/cli-plugin-recorder/raw/master/bin/win64/cli-recorder.exe) [`linux64`](https://github.com/simonleung8/cli-plugin-recorder/raw/master/bin/linux64/cli-recorder.linux64) [`osx`](https://github.com/simonleung8/cli-plugin-recorder/raw/master/bin/osx/cli-recorder.osx)
 - Install plugin `$ cf install-plugin <binary_name>`
 
 
 
-#####Install from Source (need to have [Go](http://golang.org/dl/) installed)
+##### Install from Source (need to have [Go](http://golang.org/dl/) installed)
   ```
   $ go get github.com/cloudfoundry/cli
   $ go get github.com/simonleung8/cli-plugin-recorder
@@ -39,7 +39,7 @@ $ cf replay <name>
   $ cf install-plugin cli-recorder
   ```
 
-##Full Command List
+## Full Command List
 
 | command | usage | description|
 | :--------------- |:---------------| :------------|
@@ -51,7 +51,7 @@ $ cf replay <name>
 |`replay`|`cf replay <Cmd_Name...>`|replay a command set or sets|
 |`rp`|`cf rp <Cmd_Name...>`|alias of `replay`|
 
-##Help Command
+## Help Command
 
 | command | usage | description|
 | :--------------- |:---------------| :------------|


### PR DESCRIPTION
The headings don't currently show up correctly when the README is displayed in GitHub. This PR adds spaces to make the headings valid markdown.